### PR TITLE
WIP Auto Save 

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -433,10 +433,14 @@ describe('VisualEditor', () => {
 		  "addObjective": [Function],
 		  "contentRect": null,
 		  "editable": false,
+		  "elapsed": 0,
+		  "intervalId": 108,
+		  "lastSaved": null,
 		  "objectives": Array [],
 		  "removeObjective": [Function],
 		  "saveState": "saveSuccessful",
 		  "showPlaceholders": true,
+		  "unsavedChanges": false,
 		  "updateObjective": [Function],
 		  "value": Array [
 		    Object {
@@ -458,10 +462,14 @@ describe('VisualEditor', () => {
 		  "addObjective": [Function],
 		  "contentRect": null,
 		  "editable": true,
+		  "elapsed": 0,
+		  "intervalId": 114,
+		  "lastSaved": null,
 		  "objectives": Array [],
 		  "removeObjective": [Function],
 		  "saveState": "",
 		  "showPlaceholders": true,
+		  "unsavedChanges": false,
 		  "updateObjective": [Function],
 		  "value": Array [
 		    Object {
@@ -679,6 +687,20 @@ describe('VisualEditor', () => {
 		component.unmount()
 
 		expect(plugins).toMatchSnapshot()
+	})
+
+	test('draft saves to local storage every 10 seconds', () => {
+		jest.useFakeTimers();
+
+		const saveModuleToLocalStorage = jest.spyOn(VisualEditor.prototype, 'saveModuleToLocalStorage');
+
+		expect(setInterval).toHaveBeenCalledTimes(1);
+		expect(setInterval).toHaveBeenLastCalledWith(expect(saveModuleToLocalStorage), 10000);
+	})
+
+	test('lastSaved displays in toolbar after save', () => {
+		const component = mount(<VisualEditor {...props}/>)
+
 	})
 
 	test('exportToJSON returns expected json for assessment node', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
@@ -99,6 +99,7 @@ class CodeEditor extends React.Component {
 		location.reload()
 	}
 
+	//TARGET
 	saveAndGetTitleFromCode() {
 		// Update the title in the File Toolbar
 		const title = EditorUtil.getTitleFromString(this.state.code, this.props.mode)

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.scss
@@ -14,6 +14,7 @@
 	min-height: calc(100vh - 10.5em);
 	position: relative;
 	min-width: 56.5em;
+	z-index: 0;
 
 	.obojobo-draft--modules--module {
 		margin: 3em auto;
@@ -36,6 +37,20 @@
 		letter-spacing: -0.025em;
 		display: inline;
 		cursor: text;
+	}
+
+	.lastSaved {
+		position: absolute;
+		top: 2.8em;
+		right: 12em;
+		font-family: $font-default;
+		font-size: 0.8em;
+		padding-left: 3em;
+		display: inline-block;
+		pointer-events: none;
+		text-align: center;
+		font-weight: bold;
+		color: $color-text-minor
 	}
 
 	.skip-nav {


### PR DESCRIPTION
This PR allows for auto saving the editor whilst a user is working on it. The way this works is that there is an interval set for every minute that compares the saved JSON to the page's current JSON, if different than it saves the current JSON into local storage. If editor is still not saved after the user refreshes the client, then the client will pop up with a modal asking if the user would like to overwrite their changes, to which they can either confirm or deny. Additionally, this PR implements a "Last saved Xm ago" text in the file toolbar after the user saves, indicating to the user that it has been X amount of time since they have saved the module. 
The reasons for this PR being a WIP are:
1.) Testing was not complete
2.) A browser alert still pops up even after confirming to overwrite changes that indicates "changes may not be saved". This code lies within the `checIfSaved` function that would need a conditional to fix it.

All of the code written for this branch are in the `visual-editor.js`, `editor-app.js`, and their corresponding test files. 